### PR TITLE
[ID21AH-495] Add clock tolerance to JWT verification

### DIFF
--- a/dist/src/common/utils/jwt.utils.js
+++ b/dist/src/common/utils/jwt.utils.js
@@ -34,7 +34,7 @@ export function decodeToken(jsonWebtoken) {
 export function verifyJwtWithExpAndAudience(token, publicKeyJWK, audience) {
     return __awaiter(this, void 0, void 0, function* () {
         const publicKey = yield importJWK(publicKeyJWK);
-        const payload = yield jwtVerify(token, publicKey);
+        const payload = yield jwtVerify(token, publicKey, { clockTolerance: 5 });
         if (!payload.payload.exp || payload.payload.exp < Math.floor(Date.now() / 1000)) {
             throw new InvalidToken("JWT is expired or does not have exp parameter");
         }

--- a/src/common/utils/jwt.utils.ts
+++ b/src/common/utils/jwt.utils.ts
@@ -32,7 +32,7 @@ export async function verifyJwtWithExpAndAudience(
   audience?: string
 ) {
   const publicKey = await importJWK(publicKeyJWK);
-  const payload = await jwtVerify(token, publicKey);
+  const payload = await jwtVerify(token, publicKey, { clockTolerance: 5 });
   if (!payload.payload.exp || payload.payload.exp < Math.floor(Date.now() / 1000)) {
     throw new InvalidToken("JWT is expired or does not have exp parameter");
   }


### PR DESCRIPTION
## Description

Clock tolerance of five seconds added to JWT "exp" claim verifcation.

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
[ID21AH-495](https://wealize.atlassian.net/browse/ID21AH-495)

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs in project
- [ ] 🍕 Shared with team / daily
- [X] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  
  Before submitting a Pull Request, please ensure you've done the following:
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Guide: https://github.com/Wealize/-ORG-good_practices/blob/main/PR/README.md
  - 👷‍♀️ Create small / functional commits. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->


  


[ID21AH-495]: https://wealize.atlassian.net/browse/ID21AH-495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ