### PR TITLE
Feat/credential subject callback

### DIFF
--- a/dist/src/common/classes/control_proof.d.ts
+++ b/dist/src/common/classes/control_proof.d.ts
@@ -14,6 +14,7 @@ export declare abstract class ControlProof {
      * Express the proof as a object that contains only the attributes
      */
     abstract toJSON(): Record<string, string>;
+    abstract getProofField(fieldName: string): any;
     /**
      * Allows to verify a proof
      * @param cNonce Challenge nonce that should contain the proof
@@ -39,9 +40,11 @@ export declare abstract class ControlProof {
 declare class JwtControlProof extends ControlProof {
     private jwt;
     private clientIdentifier?;
+    private decodedJwt;
     constructor(format: ControlProofType, jwt: string);
     toJSON(): Record<string, string>;
     getAssociatedIdentifier(): string;
+    getProofField(fieldName: string): any;
     verifyProof(cNonce: string, audience: string, didResolver: Resolvable): Promise<void>;
 }
 export {};

--- a/dist/src/common/classes/control_proof.js
+++ b/dist/src/common/classes/control_proof.js
@@ -51,6 +51,7 @@ class JwtControlProof extends ControlProof {
     constructor(format, jwt) {
         super(format);
         this.jwt = jwt;
+        this.decodedJwt = decodeToken(this.jwt);
     }
     toJSON() {
         return {
@@ -60,7 +61,7 @@ class JwtControlProof extends ControlProof {
     }
     getAssociatedIdentifier() {
         if (!this.clientIdentifier) {
-            const { header, payload } = decodeToken(this.jwt);
+            const { header, payload } = this.decodedJwt;
             if (!header.kid) {
                 throw new InvalidProof(`"kid" parameter must be specified`);
             }
@@ -68,10 +69,13 @@ class JwtControlProof extends ControlProof {
         }
         return this.clientIdentifier;
     }
+    getProofField(fieldName) {
+        return this.decodedJwt.payload[fieldName];
+    }
     verifyProof(cNonce, audience, didResolver) {
         var _a;
         return __awaiter(this, void 0, void 0, function* () {
-            const { header, payload } = decodeToken(this.jwt);
+            const { header, payload } = this.decodedJwt;
             const jwtPayload = payload;
             if (!header.typ || header.typ !== "openid4vci-proof+jwt") {
                 throw new InvalidProof(`Invalid "typ" paramater in proof header`);

--- a/dist/src/core/credentials/types.d.ts
+++ b/dist/src/core/credentials/types.d.ts
@@ -2,7 +2,8 @@ import { W3CVerifiableCredentialFormats } from "../../common/formats/index.js";
 import { W3CCredentialStatus, W3CSingleCredentialSubject, W3CVcSchemaDefinition, W3CVerifiableCredential } from "../../common/interfaces/w3c_verifiable_credential.interface.js";
 import { CompactVc, VerificationResult } from "../../common/types/index.js";
 import { JWK } from "jose";
-import { JwtHeader, JwtPayload } from "jsonwebtoken";
+import { Jwt, JwtHeader, JwtPayload } from "jsonwebtoken";
+import { CredentialRequest } from "../../common/interfaces/credential_request.interface.js";
 /**
  * Function type that allows to verify the contents, but no the
  * signature, of an acess token
@@ -27,6 +28,13 @@ export type VcSignCallback = (format: W3CVerifiableCredentialFormats, vc: W3CVer
 export type DeferredExchangeCallback = (acceptanceToken: string) => Promise<ExtendedCredentialDataOrDeferred | {
     error: string;
 }>;
+/**
+ * Function type that resolve credential subject from credential request and access token
+ * @param accessToken
+ * @param credentialRequest
+ * @returns Credential Subject
+ */
+export type ResolveCredentialSubject = (accessToken: Jwt, credentialRequest: CredentialRequest) => Promise<string>;
 /**
  * Contains the subject data of a VC along with its type and format,
  * It can also contains a deferred code

--- a/dist/src/core/credentials/vc_issuer.d.ts
+++ b/dist/src/core/credentials/vc_issuer.d.ts
@@ -17,6 +17,7 @@ export declare class W3CVcIssuer {
     private cNonceRetrieval;
     private getVcSchema;
     private getCredentialData;
+    private resolveCredentialSubject;
     /**
      * Constructor of the issuer
      * @param metadata Issuer metadata
@@ -30,7 +31,7 @@ export declare class W3CVcIssuer {
      * include in the VC
      * It can also be used to specify if the user should follow the deferred flow
      */
-    constructor(metadata: IssuerMetadata, didResolver: Resolver, issuerDid: string, signCallback: VcIssuerTypes.VcSignCallback, cNonceRetrieval: VcIssuerTypes.ChallengeNonceRetrieval, getVcSchema: VcIssuerTypes.GetCredentialSchema, getCredentialData: VcIssuerTypes.GetCredentialData);
+    constructor(metadata: IssuerMetadata, didResolver: Resolver, issuerDid: string, signCallback: VcIssuerTypes.VcSignCallback, cNonceRetrieval: VcIssuerTypes.ChallengeNonceRetrieval, getVcSchema: VcIssuerTypes.GetCredentialSchema, getCredentialData: VcIssuerTypes.GetCredentialData, resolveCredentialSubject: VcIssuerTypes.ResolveCredentialSubject);
     /**
      * Allows to verify a JWT Access Token in string format
      * @param token The access token

--- a/src/core/credentials/types.ts
+++ b/src/core/credentials/types.ts
@@ -7,7 +7,10 @@ import {
 } from "../../common/interfaces/w3c_verifiable_credential.interface.js";
 import { CompactVc, VerificationResult } from "../../common/types/index.js";
 import { JWK } from "jose";
-import { JwtHeader, JwtPayload } from "jsonwebtoken";
+import { Jwt, JwtHeader, JwtPayload } from "jsonwebtoken";
+import {
+  CredentialRequest
+} from "../../common/interfaces/credential_request.interface.js";
 
 /**
  * Function type that allows to verify the contents, but no the 
@@ -41,6 +44,17 @@ export type VcSignCallback = (
 export type DeferredExchangeCallback = (
   acceptanceToken: string
 ) => Promise<ExtendedCredentialDataOrDeferred | { error: string }>
+
+/**
+ * Function type that resolve credential subject from credential request and access token
+ * @param accessToken
+ * @param credentialRequest
+ * @returns Credential Subject
+ */
+export type ResolveCredentialSubject = (
+  accessToken: Jwt,
+  credentialRequest: CredentialRequest
+) => Promise<string>
 
 /**
  * Contains the subject data of a VC along with its type and format, 


### PR DESCRIPTION
## Description

The subject of the credential depends on the identity model. This part of the logic is defined as a callback to be resolved by the microservice.

Additionally, from the proof of possession, we need to extract the derivation path, for which an additional method is created.

Feat needed for Alastria EPIC implementation - Alt 1. 

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
https://github.com/Wealize/identfy-vc-service/pull/2
https://wealize.atlassian.net/browse/INCPP122DG-27
https://wealize.atlassian.net/browse/INCPP122DG-30

## Screenshots/Recordings that might be useful


## Added tests?

Functional test of  https://github.com/Wealize/examples-and-tests/tree/feat/identfy-flow-tests/src/identfy/flows 

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs in project
- [ ] 🍕 Shared with team / daily
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  
  Before submitting a Pull Request, please ensure you've done the following:
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Guide: https://github.com/Wealize/-ORG-good_practices/blob/main/PR/README.md
  - 👷‍♀️ Create small / functional commits. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->


  
