### PR TITLE
[EBSIVECTOR-81] Add method to generate a Credential Response with no Access Token

### DIFF
--- a/dist/src/common/classes/control_proof.d.ts
+++ b/dist/src/common/classes/control_proof.d.ts
@@ -11,6 +11,10 @@ export declare abstract class ControlProof {
      */
     abstract getAssociatedIdentifier(): string;
     /**
+     * Allows to obtain the nonce included in the proof
+     */
+    abstract getInnerNonce(): string;
+    /**
      * Express the proof as a object that contains only the attributes
      */
     abstract toJSON(): Record<string, string>;
@@ -42,6 +46,7 @@ declare class JwtControlProof extends ControlProof {
     constructor(format: ControlProofType, jwt: string);
     toJSON(): Record<string, string>;
     getAssociatedIdentifier(): string;
+    getInnerNonce(): string;
     verifyProof(cNonce: string, audience: string, didResolver: Resolvable): Promise<void>;
 }
 export {};

--- a/dist/src/common/classes/control_proof.js
+++ b/dist/src/common/classes/control_proof.js
@@ -68,6 +68,14 @@ class JwtControlProof extends ControlProof {
         }
         return this.clientIdentifier;
     }
+    getInnerNonce() {
+        const { payload } = decodeToken(this.jwt);
+        const jwtPayload = payload;
+        if (!jwtPayload.nonce) {
+            throw new InvalidProof(`"nonce" parameter is not specified`);
+        }
+        return jwtPayload.nonce;
+    }
     verifyProof(cNonce, audience, didResolver) {
         var _a;
         return __awaiter(this, void 0, void 0, function* () {

--- a/dist/src/core/credentials/types.d.ts
+++ b/dist/src/core/credentials/types.d.ts
@@ -1,5 +1,5 @@
 import { W3CVerifiableCredentialFormats } from "../../common/formats/index.js";
-import { W3CCredentialStatus, W3CSingleCredentialSubject, W3CVcSchemaDefinition, W3CVerifiableCredential } from "../../common/interfaces/w3c_verifiable_credential.interface.js";
+import { W3CCredentialStatus, W3CSingleCredentialSubject, W3CTermsOfUse, W3CVcSchemaDefinition, W3CVerifiableCredential } from "../../common/interfaces/w3c_verifiable_credential.interface.js";
 import { CompactVc, VerificationResult } from "../../common/types/index.js";
 import { JWK } from "jose";
 import { JwtHeader, JwtPayload } from "jsonwebtoken";
@@ -101,6 +101,13 @@ export interface BaseOptionalParams {
      * @param holder The identifier of the holder of the VC
      */
     getCredentialStatus?: (types: string[], credentialId: string, holder: string) => Promise<W3CCredentialStatus>;
+    /**
+     *
+     * @param types
+     * @param holder
+     * @returns
+     */
+    getTermsOfUse?: (types: string[], holder: string) => Promise<W3CTermsOfUse>;
     /**
      * Challenge nonce to send with the credential response
      */

--- a/dist/src/core/credentials/vc_issuer.d.ts
+++ b/dist/src/core/credentials/vc_issuer.d.ts
@@ -1,7 +1,7 @@
 import { Resolver } from "did-resolver";
 import { JWK } from "jose";
 import { Jwt } from "jsonwebtoken";
-import { W3CDataModel } from "../../common/formats/index.js";
+import { W3CDataModel, W3CVerifiableCredentialFormats } from "../../common/formats/index.js";
 import { CredentialRequest } from "../../common/interfaces/credential_request.interface.js";
 import { IssuerMetadata } from "../../common/interfaces/issuer_metadata.interface.js";
 import { CredentialResponse } from "../../common/interfaces/credential_response.interface.js";
@@ -53,6 +53,7 @@ export declare class W3CVcIssuer {
      * @throws If data provided is incorrect
      */
     generateCredentialResponse(acessToken: string | Jwt, credentialRequest: CredentialRequest, dataModel: W3CDataModel, optionalParamaters?: VcIssuerTypes.GenerateCredentialReponseOptionalParams): Promise<CredentialResponse>;
+    generateVcDirectMode(did: string, dataModel: W3CDataModel, types: string[], format: W3CVerifiableCredentialFormats, optionalParamaters?: VcIssuerTypes.BaseOptionalParams): Promise<CredentialResponse>;
     private generateW3CDataForV1;
     private generateW3CDataForV2;
     private generateW3CCredential;

--- a/dist/src/core/credentials/vc_issuer.js
+++ b/dist/src/core/credentials/vc_issuer.js
@@ -104,6 +104,23 @@ export class W3CVcIssuer {
             }
         });
     }
+    generateVcDirectMode(did, dataModel, types, format, optionalParamaters) {
+        return __awaiter(this, void 0, void 0, function* () {
+            this.checkCredentialTypesAndFormat(types, format);
+            const credentialDataOrDeferred = yield this.getCredentialData(types, did);
+            if (credentialDataOrDeferred.deferredCode) {
+                return {
+                    acceptance_token: credentialDataOrDeferred.deferredCode
+                };
+            }
+            else if (credentialDataOrDeferred.data) {
+                return this.generateW3CCredential(types, yield this.getVcSchema(types), did, credentialDataOrDeferred.data, format, dataModel, optionalParamaters);
+            }
+            else {
+                throw new InternalError("No credential data or deferred code received");
+            }
+        });
+    }
     generateW3CDataForV1(type, schema, subject, vcData, optionalParameters) {
         return __awaiter(this, void 0, void 0, function* () {
             const now = new Date().toISOString();
@@ -121,6 +138,8 @@ export class W3CVcIssuer {
                     yield optionalParameters.getCredentialStatus(type, vcId, subject) : undefined,
                 issuer: this.issuerDid,
                 issued: now,
+                termsOfUse: (optionalParameters && optionalParameters.getTermsOfUse) ?
+                    yield optionalParameters.getTermsOfUse(type, subject) : undefined,
                 credentialSubject: Object.assign({ id: subject }, vcData)
             };
         });
@@ -138,6 +157,8 @@ export class W3CVcIssuer {
                 id: vcId,
                 credentialStatus: (optionalParameters && optionalParameters.getCredentialStatus) ?
                     yield optionalParameters.getCredentialStatus(type, vcId, subject) : undefined,
+                termsOfUse: (optionalParameters && optionalParameters.getTermsOfUse) ?
+                    yield optionalParameters.getTermsOfUse(type, subject) : undefined,
                 issuer: this.issuerDid,
                 credentialSubject: Object.assign({ id: subject }, vcData)
             };

--- a/src/common/classes/control_proof.ts
+++ b/src/common/classes/control_proof.ts
@@ -18,6 +18,12 @@ export abstract class ControlProof {
    * Allows to obtain the DID of the user that generated the proof
    */
   abstract getAssociatedIdentifier(): string;
+
+  /**
+   * Allows to obtain the nonce included in the proof
+   */
+  abstract getInnerNonce(): string;
+
   /**
    * Express the proof as a object that contains only the attributes
    */
@@ -88,6 +94,15 @@ class JwtControlProof extends ControlProof {
       this.clientIdentifier = obtainDid(header.kid, (payload as JwtPayload).iss);
     }
     return this.clientIdentifier;
+  }
+
+  getInnerNonce(): string {
+    const { payload } = decodeToken(this.jwt);
+    const jwtPayload = payload as JwtPayload;
+    if (!jwtPayload.nonce) {
+      throw new InvalidProof(`"nonce" parameter is not specified`);
+    }
+    return jwtPayload.nonce
   }
 
   async verifyProof(

--- a/src/core/credentials/types.ts
+++ b/src/core/credentials/types.ts
@@ -2,6 +2,7 @@ import { W3CVerifiableCredentialFormats } from "../../common/formats/index.js";
 import {
   W3CCredentialStatus,
   W3CSingleCredentialSubject,
+  W3CTermsOfUse,
   W3CVcSchemaDefinition,
   W3CVerifiableCredential,
 } from "../../common/interfaces/w3c_verifiable_credential.interface.js";
@@ -131,6 +132,16 @@ export interface BaseOptionalParams {
     credentialId: string,
     holder: string
   ) => Promise<W3CCredentialStatus>;
+  /**
+   * 
+   * @param types 
+   * @param holder 
+   * @returns 
+   */
+  getTermsOfUse?: (
+    types: string[],
+    holder: string
+  ) => Promise<W3CTermsOfUse>;
   /**
    * Challenge nonce to send with the credential response
    */


### PR DESCRIPTION
[EBSIVECTOR-81](https://wealize.atlassian.net/browse/EBSIVECTOR-81)
## Description

A new functionality has been added that allows direct credential generation without the need for an access token or proof of control. It also add a new callback related to the terms of use of a VC.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers , Jira or docs in sharepoint.

## Screenshots/Recordings that might be useful

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [x] 📓 docs in project
- [ ] 🍕 Shared with team / daily
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  
  Before submitting a Pull Request, please ensure you've done the following:
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Guide: https://github.com/Wealize/-ORG-good_practices/blob/main/PR/README.md
  - 👷‍♀️ Create small / functional commits. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->


  


[EBSIVECTOR-81]: https://wealize.atlassian.net/browse/EBSIVECTOR-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ